### PR TITLE
Exports runtime dependencies for use by tools/ion-hash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,7 @@ jdk:
   - oraclejdk8
   - oraclejdk9
   - oraclejdk11
+script:
+  - echo hello > test.ion
+  - tools/ion-hash md5 test.ion
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ jdk:
   - oraclejdk9
   - oraclejdk11
 script:
+  - mvn test -B
   - echo hello > test.ion
   - tools/ion-hash md5 test.ion
 

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,23 @@
         </executions>
       </plugin>
 
+      <!-- copy runtime dependencies to target/lib (for tools/ion-hash) -->
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>install</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <includeScope>runtime</includeScope>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <!-- run the unit tests -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
With these changes, `mvn install` copies the ion-java dependency to `target/lib`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
